### PR TITLE
fix(resource limits): fix limits.cpu for opentelemetry-collector

### DIFF
--- a/infra/otelcol/values.yml
+++ b/infra/otelcol/values.yml
@@ -57,4 +57,5 @@ resources:
     cpu: "0.1"
     memory: 50Mi
   limits:
+    cpu: "0.1"
     memory: 50Mi


### PR DESCRIPTION
- Fixed the error failed quota: resource-limits: must specify limits.cpu for: opentelemetry-collector.